### PR TITLE
ci(workflows): add devctl-generated GitHub Actions workflows

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -1,0 +1,30 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/v7.33.1/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+#
+name: Create Release
+
+on:
+  push:
+    branches:
+      - 'legacy'
+      - 'main'
+      - 'master'
+      - 'release-v*.*.x'
+      # "!" negates previous positive patterns so it has to be at the end.
+      - '!release-v*.x.x'
+
+permissions: {}
+
+jobs:
+  create-release:
+    uses: giantswarm/github-workflows/.github/workflows/create-release.yaml@main
+    with:
+      build-release-artifacts: false
+      fetch-deep-gitlog-for-build: true
+    secrets:
+      TAYLORBOT_GITHUB_ACTION: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+    permissions:
+      contents: write

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -1,0 +1,43 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/v7.33.1/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+#
+name: Create Release PR
+on:
+  push:
+    branches:
+      - 'legacy#release#v*.*.*'
+      - 'main#release#v*.*.*'
+      - 'main#release#major'
+      - 'main#release#minor'
+      - 'main#release#patch'
+      - 'master#release#v*.*.*'
+      - 'master#release#major'
+      - 'master#release#minor'
+      - 'master#release#patch'
+      - 'release#v*.*.*'
+      - 'release#major'
+      - 'release#minor'
+      - 'release#patch'
+      - 'release-v*.*.x#release#v*.*.*'
+      # "!" negates previous positive patterns so it has to be at the end.
+      - '!release-v*.x.x#release#v*.*.*'
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    uses: giantswarm/github-workflows/.github/workflows/create-release-pr.yaml@main
+    permissions:
+      contents: read
+    with:
+      branch: ${{ inputs.branch }}
+    secrets:
+      TAYLORBOT_GITHUB_ACTION: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,0 +1,18 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/v7.33.1/pkg/gen/input/workflows/internal/file/gitleaks.yaml.template
+#
+name: gitleaks
+
+on:
+  - pull_request
+
+permissions: {}
+
+jobs:
+  publish:
+    uses: giantswarm/github-workflows/.github/workflows/gitleaks.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/zz_generated.run_ossf_scorecard.yaml
+++ b/.github/workflows/zz_generated.run_ossf_scorecard.yaml
@@ -1,0 +1,41 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/v7.33.1/pkg/gen/input/workflows/internal/file/run_ossf_scorecard.yaml.template
+#
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule: {}
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '15 15 15 * *'
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  analysis:
+    uses: giantswarm/github-workflows/.github/workflows/ossf-scorecard.yaml@main
+    permissions:
+      contents: read
+      actions: read
+      issues: read
+      pull-requests: read
+      checks: read
+      security-events: write
+      id-token: write
+    secrets:
+      scorecard_token: ${{ secrets.SCORECARD_TOKEN }}

--- a/.github/workflows/zz_generated.validate_changelog.yaml
+++ b/.github/workflows/zz_generated.validate_changelog.yaml
@@ -1,0 +1,22 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/v7.33.1/pkg/gen/input/workflows/internal/file/validate_changelog.yaml.template
+#
+name: Validate changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'CHANGELOG.md'
+
+permissions: {}
+
+jobs:
+  validate-changelog:
+    uses: giantswarm/github-workflows/.github/workflows/validate-changelog.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Add five standard GitHub Actions workflows generated by devctl v7.33.1: create-release, create-release-pr, gitleaks, ossf-scorecard, and validate-changelog. These bring the repo in line with standard Giant Swarm CI tooling for releases and supply-chain security.