### PR TITLE
ci: fix Makefile clean/build target conflicts and replace architect make check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,11 @@ jobs:
           curl -fsSL "https://dl.k8s.io/v1.35.2/bin/linux/amd64/kube-apiserver" -o "$(go env GOPATH)/bin/kube-apiserver"
           chmod +x "$(go env GOPATH)/bin/kube-apiserver"
 
-      - name: Run Checks (Lint & Test)
-        run: make check
+      - name: Run lint
+        run: golangci-lint run --config .golangci.yml
+
+      - name: Run integration tests
+        run: make test-integration
 
       - name: Run govulncheck (Security Scan)
         run: make govulncheck

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ include Makefile.*.mk
 # default goal 001
 .DEFAULT_GOAL := help
 
-.PHONY: clean
-clean:: ## Remove build artifacts and temp directories
-
 .PHONY: help
 help: ## Show this help message
 	@awk '/^##@/ { printf "\n\033[0;32m%s\033[0m\n", substr($$0, 5) } \

--- a/Makefile.lib.mk
+++ b/Makefile.lib.mk
@@ -26,7 +26,3 @@ lint-fix: ## Run golangci-lint with auto-fix
 deps: ## Download and tidy dependencies
 	go mod download
 	go mod tidy
-
-.PHONY: clean
-clean::
-	go clean

--- a/Makefile.test.mk
+++ b/Makefile.test.mk
@@ -42,8 +42,3 @@ coverage: ## Generate test coverage report (requires kine and kube-apiserver)
 .PHONY: coverage-html
 coverage-html: coverage ## Generate and open coverage report in browser
 	go tool cover -html=$(COVERAGE_FILE)
-
-
-.PHONY: clean
-clean::
-	rm -f $(COVERAGE_FILE)

--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -39,3 +39,8 @@ download-capi-crds: ## Download CAPI core CRDs
 .PHONY: clean-crds
 clean-crds: ## Remove downloaded CRDs
 	rm -f crds/*.yaml
+
+.PHONY: clean
+clean: ## Remove build artifacts and temp directories
+	go clean
+	rm -f $(COVERAGE_FILE)


### PR DESCRIPTION
## Summary

- Reconcile duplicate `clean` targets: drop the `clean::` (double colon) entries from `Makefile` / `Makefile.dev.mk` / `Makefile.test.mk` and add a single canonical `clean:` in `Makefile.tools.mk` that overrides the single-colon `clean:` in the generated `Makefile.gen.go.mk`.
- Rename `Makefile.dev.mk` -> `Makefile.lib.mk` so its `build` / `fmt` / `lint` recipes sort after `Makefile.gen.go.mk` and win the override (ASCII: `gen.go` < `lib`).
- Stop calling `make check` from the `Lint and Test` workflow. No workflow in this repo uses `architect`, so we avoid the noisy `architect: No such file or directory` stderr from parse-time `$(shell architect project version)` in the generated file. The workflow now calls `golangci-lint run --config .golangci.yml` and `make test-integration` directly.

This unblocks architectbot Align files PR #20 and any future Renovate / alignment PRs that happen to land alongside `Makefile.gen.go.mk`.

Verified locally in a simulated merged tree (main + `Makefile.gen.go.mk` from PR #20) that `make -n check` now exits 0, with only benign "overriding recipe" warnings for `build` / `fmt` / `lint` / `clean` (the library-appropriate recipes win).

Closes #23

## Test plan

- [ ] `Lint and Test` job passes on this PR.
- [ ] Re-running failed checks on PR #20 (after this merges and it rebases) passes `Lint and Test`.
- [ ] PR #20 auto-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)